### PR TITLE
Remove transaction immutibility support.

### DIFF
--- a/src/main/java/io/r2dbc/h2/H2Connection.java
+++ b/src/main/java/io/r2dbc/h2/H2Connection.java
@@ -16,27 +16,21 @@
 
 package io.r2dbc.h2;
 
+import static io.r2dbc.spi.IsolationLevel.*;
+import static org.h2.engine.Constants.*;
+
+import java.util.Objects;
+import java.util.function.Function;
+
 import io.r2dbc.h2.client.Client;
 import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.IsolationLevel;
-import io.r2dbc.spi.Mutability;
 import org.h2.message.DbException;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-
-import java.util.Objects;
-import java.util.function.Function;
-
-import static io.r2dbc.spi.IsolationLevel.READ_COMMITTED;
-import static io.r2dbc.spi.IsolationLevel.READ_UNCOMMITTED;
-import static io.r2dbc.spi.IsolationLevel.REPEATABLE_READ;
-import static io.r2dbc.spi.IsolationLevel.SERIALIZABLE;
-import static org.h2.engine.Constants.LOCK_MODE_OFF;
-import static org.h2.engine.Constants.LOCK_MODE_READ_COMMITTED;
-import static org.h2.engine.Constants.LOCK_MODE_TABLE;
 
 /**
  * An implementation of {@link Connection} for connecting to an H2 database.
@@ -160,14 +154,6 @@ public final class H2Connection implements Connection {
 
         return this.client.execute(getTransactionIsolationLevelQuery(isolationLevel))
             .onErrorMap(DbException.class, H2DatabaseException::new);
-    }
-
-    @Override
-    public Mono<Void> setTransactionMutability(Mutability mutability) {
-        Objects.requireNonNull(mutability, "mutability must not be null");
-
-        // TODO: Implement transaction mutability
-        return Mono.error(new UnsupportedOperationException("Transaction mutability not supported"));
     }
 
     private static String getTransactionIsolationLevelQuery(IsolationLevel isolationLevel) {

--- a/src/test/java/io/r2dbc/h2/H2ConnectionTest.java
+++ b/src/test/java/io/r2dbc/h2/H2ConnectionTest.java
@@ -16,21 +16,16 @@
 
 package io.r2dbc.h2;
 
+import static io.r2dbc.spi.IsolationLevel.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
 import io.r2dbc.h2.client.Client;
 import org.h2.message.DbException;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
-
-import static io.r2dbc.spi.IsolationLevel.READ_COMMITTED;
-import static io.r2dbc.spi.Mutability.READ_ONLY;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNullPointerException;
-import static org.mockito.Mockito.RETURNS_SMART_NULLS;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 
 final class H2ConnectionTest {
 
@@ -319,48 +314,6 @@ final class H2ConnectionTest {
 
         new H2Connection(this.client)
             .setTransactionIsolationLevel(READ_COMMITTED)
-            .as(StepVerifier::create)
-            .verifyComplete();
-    }
-
-    @Disabled("Not yet implemented")
-    @Test
-    void setTransactionMutability() {
-        when(this.client.inTransaction()).thenReturn(true);
-        when(this.client.execute("SET TRANSACTION READ ONLY")).thenReturn(Mono.empty());
-
-        new H2Connection(this.client)
-            .setTransactionMutability(READ_ONLY)
-            .as(StepVerifier::create)
-            .verifyComplete();
-    }
-
-    @Disabled("Not yet implemented")
-    @Test
-    void setTransactionMutabilityErrorResponse() {
-        when(this.client.inTransaction()).thenReturn(true);
-        when(this.client.execute("SET TRANSACTION READ ONLY")).thenThrow(DbException.get(0));
-
-        new H2Connection(this.client)
-            .setTransactionIsolationLevel(READ_COMMITTED)
-            .as(StepVerifier::create)
-            .verifyErrorMatches(H2DatabaseException.class::isInstance);
-    }
-
-    @Test
-    void setTransactionMutabilityNoMutability() {
-        assertThatNullPointerException().isThrownBy(() -> new H2Connection(this.client).setTransactionMutability(null))
-            .withMessage("mutability must not be null");
-    }
-
-    @Disabled("Not yet implemented")
-    @Test
-    void setTransactionMutabilityNonOpen() {
-        when(this.client.inTransaction()).thenReturn(false);
-        verifyNoMoreInteractions(this.client);
-
-        new H2Connection(this.client)
-            .setTransactionMutability(READ_ONLY)
             .as(StepVerifier::create)
             .verifyComplete();
     }

--- a/src/test/java/io/r2dbc/h2/H2Example.java
+++ b/src/test/java/io/r2dbc/h2/H2Example.java
@@ -20,7 +20,6 @@ import io.r2dbc.h2.util.H2ServerExtension;
 import io.r2dbc.spi.test.Example;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.jdbc.core.JdbcOperations;
 
@@ -73,13 +72,6 @@ final class H2Example {
     @Nested
     final class PostgresqlStyle implements Example<String> {
 
-        @Disabled("Not yet implemented")
-        @Override
-        @Test
-        public void connectionMutability() {
-            // TODO: Remove once implemented
-        }
-
         @Override
         public H2ConnectionFactory getConnectionFactory() {
             return H2Example.this.connectionFactory;
@@ -104,13 +96,6 @@ final class H2Example {
         @Override
         public String getPlaceholder(int index) {
             return String.format("$%d", index + 1);
-        }
-
-        @Disabled("Not yet implemented")
-        @Override
-        @Test
-        public void transactionMutability() {
-            // TODO: Remove once implemented
         }
     }
 }


### PR DESCRIPTION
The SPI has removed transaction immutability so this removes any TODOs or implied contracts and tests involving it.

See: https://github.com/r2dbc/r2dbc-spi/issues/14