### PR TITLE
Simplify connection configuration settings.

### DIFF
--- a/src/main/java/io/r2dbc/h2/H2ConnectionConfiguration.java
+++ b/src/main/java/io/r2dbc/h2/H2ConnectionConfiguration.java
@@ -26,16 +26,13 @@ import java.util.Optional;
  */
 public final class H2ConnectionConfiguration {
 
-    private final String database;
-
     private final String password;
 
     private final String url;
 
     private final String username;
 
-    private H2ConnectionConfiguration(@Nullable String database, @Nullable String password, String url, @Nullable String username) {
-        this.database = database;
+    private H2ConnectionConfiguration(@Nullable String password, String url, @Nullable String username) {
         this.password = password;
         this.url = Objects.requireNonNull(url, "url must not be null");
         this.username = username;
@@ -53,15 +50,10 @@ public final class H2ConnectionConfiguration {
     @Override
     public String toString() {
         return "H2ConnectionConfiguration{" +
-            "database='" + this.database + '\'' +
-            ", password='" + this.password + '\'' +
+            "password='" + this.password + '\'' +
             ", url='" + this.url + '\'' +
             ", username='" + this.username + '\'' +
             '}';
-    }
-
-    Optional<String> getDatabase() {
-        return Optional.ofNullable(this.database);
     }
 
     Optional<String> getPassword() {
@@ -83,8 +75,6 @@ public final class H2ConnectionConfiguration {
      */
     public static final class Builder {
 
-        private String database;
-
         private String password;
 
         private String url;
@@ -97,20 +87,28 @@ public final class H2ConnectionConfiguration {
          * @return a configured {@link H2ConnectionConfiguration}
          */
         public H2ConnectionConfiguration build() {
-            return new H2ConnectionConfiguration(this.database, this.password, this.url, this.username);
+            return new H2ConnectionConfiguration(this.password, this.url, this.username);
         }
 
         /**
-         * Configure the database.
+         * Configure a file-based database, e.g. {@literal ~/my-database} or {@literal /path/to/my/database.db}.
          *
-         * @param database the database
+         * @param path of the database file (automatically prefixed with {@literal "file:"})
          * @return this {@link Builder}
          */
-        public Builder database(@Nullable String database) {
-            this.database = database;
-            return this;
+        public Builder file(String path) {
+            return url(String.format("file:%s", path));
         }
 
+        /**
+         * Configure an in-memory database, e.g. {@literal my-test-database}.
+         *
+         * @param name of a private, in-memory database (automatically prefixed with {@literal "mem:"})
+         * @return this {@link Builder}
+         */
+        public Builder inMemory(String name) {
+            return url(String.format("mem:%s", name));
+        }
         /**
          * Configure the password.
          *
@@ -125,15 +123,19 @@ public final class H2ConnectionConfiguration {
         @Override
         public String toString() {
             return "Builder{" +
-                "database='" + this.database + '\'' +
-                ", password='" + this.password + '\'' +
+                "password='" + this.password + '\'' +
                 ", url='" + this.url + '\'' +
                 ", username='" + this.username + '\'' +
                 '}';
         }
 
         /**
-         * Configure the url.
+         * Configure the database url. Includes everything between the "jdbc:h2:" prefix and any ";" options on the end.
+         * For in-memory and file-based databases, must include the proper prefix (e.g. {@literal file:} or {@literal mem:}).
+         * <br>
+         * Does NOT include the H2 {@literal "jdbc:h2"} connection designator.
+         * <br>
+         * See http://www.h2database.com/html/features.html#database_url for more details.
          *
          * @param url the url
          * @return this {@link Builder}

--- a/src/main/java/io/r2dbc/h2/H2ConnectionFactory.java
+++ b/src/main/java/io/r2dbc/h2/H2ConnectionFactory.java
@@ -72,8 +72,7 @@ public final class H2ConnectionFactory implements ConnectionFactory {
     }
 
     private static ConnectionInfo getConnectionInfo(H2ConnectionConfiguration configuration) {
-        StringBuilder sb = new StringBuilder(START_URL).append(configuration.getUrl()).append(":");
-        configuration.getDatabase().ifPresent(sb::append);
+        StringBuilder sb = new StringBuilder(START_URL).append(configuration.getUrl());
         configuration.getUsername().ifPresent(username -> sb.append(";USER=").append(username));
         configuration.getPassword().ifPresent(password -> sb.append(";PASSWORD=").append(password));
 

--- a/src/test/java/io/r2dbc/h2/H2ConnectionFactoryTest.java
+++ b/src/test/java/io/r2dbc/h2/H2ConnectionFactoryTest.java
@@ -35,7 +35,35 @@ final class H2ConnectionFactoryTest {
     @Test
     void create() {
         H2ConnectionConfiguration configuration = H2ConnectionConfiguration.builder()
-            .url("mem")
+            .url("mem:foo")
+            .username("sa")
+            .password("")
+            .build();
+
+        new H2ConnectionFactory(configuration).create()
+            .as(StepVerifier::create)
+            .expectNextCount(1)
+            .verifyComplete();
+    }
+
+    @Test
+    void createInMemoryDatabase() {
+        H2ConnectionConfiguration configuration = H2ConnectionConfiguration.builder()
+            .inMemory("in-memory-named-database")
+            .username("sa")
+            .password("")
+            .build();
+
+        new H2ConnectionFactory(configuration).create()
+            .as(StepVerifier::create)
+            .expectNextCount(1)
+            .verifyComplete();
+    }
+
+    @Test
+    void createFileBasedDatabase() {
+        H2ConnectionConfiguration configuration = H2ConnectionConfiguration.builder()
+            .file("~/test")
             .username("sa")
             .password("")
             .build();

--- a/src/test/java/io/r2dbc/h2/H2Example.java
+++ b/src/test/java/io/r2dbc/h2/H2Example.java
@@ -29,7 +29,6 @@ final class H2Example {
     static final H2ServerExtension SERVER = new H2ServerExtension();
 
     private final H2ConnectionConfiguration configuration = H2ConnectionConfiguration.builder()
-        .database(SERVER.getDatabase())
         .password(SERVER.getPassword())
         .url(SERVER.getUrl())
         .username(SERVER.getUsername())

--- a/src/test/java/io/r2dbc/h2/util/H2ServerExtension.java
+++ b/src/test/java/io/r2dbc/h2/util/H2ServerExtension.java
@@ -33,7 +33,7 @@ public final class H2ServerExtension implements BeforeAllCallback, AfterAllCallb
 
     private final String password = randomAlphanumeric(16);
 
-    private final String url = "mem";
+    private final String url = "mem:" + database;
 
     private final String username = randomAlphanumeric(16);
 
@@ -50,16 +50,12 @@ public final class H2ServerExtension implements BeforeAllCallback, AfterAllCallb
     public void beforeAll(ExtensionContext context) throws Exception {
         this.dataSource = DataSourceBuilder.create()
             .type(HikariDataSource.class)
-            .url(String.format("jdbc:h2:%s:%s;USER=%s;PASSWORD=%s;DB_CLOSE_DELAY=-1;TRACE_LEVEL_FILE=4", this.url, this.database, this.username, this.password))
+            .url(String.format("jdbc:h2:%s;USER=%s;PASSWORD=%s;DB_CLOSE_DELAY=-1;TRACE_LEVEL_FILE=4", this.url, this.username, this.password))
             .build();
 
         this.dataSource.setMaximumPoolSize(1);
 
         this.jdbcOperations = new JdbcTemplate(this.dataSource);
-    }
-
-    public String getDatabase() {
-        return this.database;
     }
 
     @Nullable


### PR DESCRIPTION
* Remove `database` as an option.
* Introduce `inMemory()` and `file()` helper methods.
* Provide more detailed javadoc notes in the API to help end users.

Resolves #15.