### PR TITLE
Include LICENSE and NOTICE files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,6 +222,16 @@
                 </configuration>
             </plugin>
         </plugins>
+        <resources>
+            <resource>
+                <directory>${project.basedir}</directory>
+                <includes>
+                    <include>LICENSE</include>
+                    <include>NOTICE</include>
+                </includes>
+                <targetPath>META-INF</targetPath>
+            </resource>
+        </resources>
     </build>
 
     <repositories>


### PR DESCRIPTION
This change updates the build to include `LICENSE` and `NOTICE` files in compliance with the Apache Software License.

[r2dbc/r2dbc-spi#36]