### PR TITLE
fix sql regex pattern when using multiline string

### DIFF
--- a/src/main/java/io/r2dbc/h2/client/Client.java
+++ b/src/main/java/io/r2dbc/h2/client/Client.java
@@ -26,16 +26,18 @@ import java.util.List;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
-import static java.util.regex.Pattern.*;
+import static java.util.regex.Pattern.CASE_INSENSITIVE;
+import static java.util.regex.Pattern.DOTALL;
+
 
 /**
  * An abstraction that wraps interaction with the H2 Database APIs.
  */
 public interface Client {
 
-    Pattern INSERT = Pattern.compile("\\s*INSERT.*", CASE_INSENSITIVE | DOTALL);
+    Pattern INSERT = Pattern.compile("[\\s]*INSERT.*", CASE_INSENSITIVE | DOTALL);
 
-    Pattern SELECT = Pattern.compile("\\s*SELECT.*", CASE_INSENSITIVE | DOTALL);
+    Pattern SELECT = Pattern.compile("[\\s]*SELECT.*", CASE_INSENSITIVE | DOTALL);
 
     /**
      * Release any resources held by the {@link Client}.

--- a/src/main/java/io/r2dbc/h2/client/Client.java
+++ b/src/main/java/io/r2dbc/h2/client/Client.java
@@ -26,16 +26,16 @@ import java.util.List;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
-import static java.util.regex.Pattern.CASE_INSENSITIVE;
+import static java.util.regex.Pattern.*;
 
 /**
  * An abstraction that wraps interaction with the H2 Database APIs.
  */
 public interface Client {
 
-    Pattern INSERT = Pattern.compile(".*INSERT.*", CASE_INSENSITIVE);
+    Pattern INSERT = Pattern.compile("\\s*INSERT.*", CASE_INSENSITIVE | DOTALL);
 
-    Pattern SELECT = Pattern.compile(".*SELECT.*", CASE_INSENSITIVE);
+    Pattern SELECT = Pattern.compile("\\s*SELECT.*", CASE_INSENSITIVE | DOTALL);
 
     /**
      * Release any resources held by the {@link Client}.

--- a/src/test/java/io/r2dbc/h2/client/ClientTest.java
+++ b/src/test/java/io/r2dbc/h2/client/ClientTest.java
@@ -1,0 +1,39 @@
+package io.r2dbc.h2.client;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ClientTest {
+    @Test
+    void selectPattern() {
+        String[] queries = {
+                "select * from dual",
+                "\r select \n* from dual",
+                "\r\n select \n\n* from dual ",
+                "\r\n select \n\n* from dual\n\r"
+        };
+
+        for (String query : queries) {
+            assertThat(Client.SELECT.matcher(query).matches()).isTrue();
+        }
+    }
+
+    @Test
+    void insertPattern() {
+        String[] queries = {
+                "insert into test(id) values(1) ",
+                "insert into test(id) select id from ids",
+                "\rinsert into test(id) values(1) ",
+                "\r\n\rinsert into test(id) values(1) ",
+                "\r\n\rinsert \n into test(id) values(1)",
+                "\r\n\rinsert \n\n into test(id) values(1) ",
+                "\r\n\rinsert \n\n into test(id) values(1)\n\r",
+                "\r\n\rinsert \n\n into test(id) select id from ids\n\r",
+        };
+
+        for (String query : queries) {
+            assertThat(Client.INSERT.matcher(query).matches()).isTrue();
+        }
+    }
+}

--- a/src/test/java/io/r2dbc/h2/client/ClientTest.java
+++ b/src/test/java/io/r2dbc/h2/client/ClientTest.java
@@ -6,34 +6,27 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class ClientTest {
     @Test
-    void selectPattern() {
-        String[] queries = {
-                "select * from dual",
-                "\r select \n* from dual",
-                "\r\n select \n\n* from dual ",
-                "\r\n select \n\n* from dual\n\r"
-        };
+    void checkSqlPattern() {
+        String selectStatement = "select * from dual";
+        String insertStatement = "insert into test(id) values(1)";
+        String insertIntoSelectStatement = "insert into test(id) select id from ids where 1 = 1";
 
-        for (String query : queries) {
-            assertThat(Client.SELECT.matcher(query).matches()).isTrue();
-        }
+        assertThat(Client.SELECT.matcher(selectStatement).matches()).isTrue();
+        assertThat(Client.SELECT.matcher(insertStatement).matches()).isFalse();
+        assertThat(Client.INSERT.matcher(insertStatement).matches()).isTrue();
+        assertThat(Client.INSERT.matcher(selectStatement).matches()).isFalse();
+        assertThat(Client.INSERT.matcher(insertIntoSelectStatement).matches()).isTrue();
+        assertThat(Client.SELECT.matcher(insertIntoSelectStatement).matches()).isFalse();
     }
 
     @Test
-    void insertPattern() {
-        String[] queries = {
-                "insert into test(id) values(1) ",
-                "insert into test(id) select id from ids",
-                "\rinsert into test(id) values(1) ",
-                "\r\n\rinsert into test(id) values(1) ",
-                "\r\n\rinsert \n into test(id) values(1)",
-                "\r\n\rinsert \n\n into test(id) values(1) ",
-                "\r\n\rinsert \n\n into test(id) values(1)\n\r",
-                "\r\n\rinsert \n\n into test(id) select id from ids\n\r",
-        };
+    void checkSqlPatternWithWhitespace() {
+        String selectStatement = "\r\n\t select\r\n\t *\r\n\t from\n\n dual \r\n\t";
+        String insertStatement = "\n\n\t insert\r\n\t into\r\n\t test(id) values(1)\r\n\t";
 
-        for (String query : queries) {
-            assertThat(Client.INSERT.matcher(query).matches()).isTrue();
-        }
+        assertThat(Client.SELECT.matcher(selectStatement).matches()).isTrue();
+        assertThat(Client.SELECT.matcher(insertStatement).matches()).isFalse();
+        assertThat(Client.INSERT.matcher(insertStatement).matches()).isTrue();
+        assertThat(Client.INSERT.matcher(selectStatement).matches()).isFalse();
     }
 }


### PR DESCRIPTION
Thank you for developing r2dbc-h2.

I encountered a bug while using the library when using kotlin's multiline string literal.

```kotlin
"""
    SELECT *
    from ACCOUNT
    where id = $1

"""

// java
//  SELECT *\n    from ACCOUNT\n    where id = $1
```

    
     org.h2.message.DbException: Method is not allowed for a query. Use execute or executeQuery instead of executeUpdate [90001-197]

---

The target to be modified is as follows.

```java
// Client.java
Pattern INSERT = Pattern.compile(".*INSERT.*", CASE_INSENSITIVE);
Pattern SELECT = Pattern.compile(".*SELECT.*", CASE_INSENSITIVE);

// H2Statement.java
private static Flux<H2Result> execute(Client client, String sql, Bindings bindings, Codecs codecs) {
        if (!SELECT.matcher(sql).matches()) {
            return client.update(sql, bindings.bindings)
                .map(result -> H2Result.toResult(result.getGeneratedKeys(), result.getUpdateCount(), codecs));
        } else {
            return client.query(sql, bindings.bindings)
                .map(result -> H2Result.toResult(result, null, codecs));
        }
    }
```

Register a pull request with modified regular expressions.

Thank you.