### PR TITLE
Remove Recursive Generics

### DIFF
--- a/src/main/java/io/r2dbc/h2/H2Batch.java
+++ b/src/main/java/io/r2dbc/h2/H2Batch.java
@@ -32,7 +32,7 @@ import static io.r2dbc.h2.client.Client.INSERT;
 /**
  * An implementation of {@link Batch} for executing a collection of statements in a batch against an H2 database.
  */
-public final class H2Batch implements Batch<H2Batch> {
+public final class H2Batch implements Batch {
 
     private final Client client;
 

--- a/src/main/java/io/r2dbc/h2/H2Statement.java
+++ b/src/main/java/io/r2dbc/h2/H2Statement.java
@@ -34,7 +34,7 @@ import static io.r2dbc.h2.client.Client.SELECT;
 /**
  * An implementation of {@link Statement} for an H2 database.
  */
-public final class H2Statement implements Statement<H2Statement> {
+public final class H2Statement implements Statement {
 
     private static final Pattern PARAMETER_SYMBOL = Pattern.compile(".*\\$([\\d]+).*");
 

--- a/src/test/java/io/r2dbc/h2/H2StatementTest.java
+++ b/src/test/java/io/r2dbc/h2/H2StatementTest.java
@@ -53,7 +53,7 @@ final class H2StatementTest {
 
     @Test
     void bindIndex() {
-        assertThat(this.statement.bind(0, 100).getCurrentBinding()).isEqualTo(new Binding().add(0, ValueInt.get(100)));
+        assertThat(((H2Statement) this.statement.bind(0, 100)).getCurrentBinding()).isEqualTo(new Binding().add(0, ValueInt.get(100)));
     }
 
     @Test


### PR DESCRIPTION
This change removes the recursive generics from this implementation to be compliant with changes made to the SPI.  These changes were driven by the observation that recursive generics made consumption of the API harder and no longer provided us much value.

[r2dbc/r2dbc-spi#24]

Signed-off-by: Ben Hale <bhale@pivotal.io>