### PR TITLE
return alias instead of the column name

### DIFF
--- a/src/main/java/io/r2dbc/h2/H2Row.java
+++ b/src/main/java/io/r2dbc/h2/H2Row.java
@@ -105,7 +105,7 @@ public final class H2Row implements Row {
         List<Column> columns = new ArrayList<>(values.length);
 
         for (int i = 0; i < values.length; i++) {
-            columns.add(new Column(result.getColumnType(i), result.getColumnName(i).toUpperCase(), values[i]));
+            columns.add(new Column(result.getColumnType(i), result.getAlias(i).toUpperCase(), values[i]));
         }
 
         return columns;

--- a/src/test/java/io/r2dbc/h2/H2RowTest.java
+++ b/src/test/java/io/r2dbc/h2/H2RowTest.java
@@ -16,10 +16,31 @@
 
 package io.r2dbc.h2;
 
-import org.junit.jupiter.api.Disabled;
+import io.r2dbc.h2.codecs.DefaultCodecs;
+import org.h2.result.ResultInterface;
+import org.h2.value.Value;
+import org.h2.value.ValueInt;
+import org.junit.jupiter.api.Test;
 
-@Disabled("Not yet implemented")
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 final class H2RowTest {
+
+    @Test
+    void makeSureThatAliasIsUsedInRow() {
+        Value[] values = {ValueInt.get(1)};
+
+        ResultInterface resultInterface = mock(ResultInterface.class);
+        when(resultInterface.getColumnType(0)).thenReturn(ValueInt.INT);
+        when(resultInterface.getColumnName(0)).thenReturn("MyColumnName");
+        when(resultInterface.getAlias(0)).thenReturn("MyColumnAlias");
+
+        H2Row h2Row = H2Row.toRow(values, resultInterface, new DefaultCodecs());
+
+        assertEquals(1, h2Row.get("MyColumnAlias"));
+    }
 
 //    private final List<Column> columns = Arrays.asList(
 //        new Column(TEST.buffer(4).writeInt(100), 200, BINARY, "test-name-1"),


### PR DESCRIPTION
`select name as myName from table` if this query is executed the method `getAlias(index)` will return `myName`

now, for the query below the `getAlias(index)` method will return name. No null value is returned from the method:
`select name from table` if this query is executed the method `getAlias(index)` will return `myName`

#43