### PR TITLE
Add ConnectionFactoryProvider.getDriver() implementation

### DIFF
--- a/src/main/java/io/r2dbc/h2/H2ConnectionFactoryProvider.java
+++ b/src/main/java/io/r2dbc/h2/H2ConnectionFactoryProvider.java
@@ -114,4 +114,8 @@ public final class H2ConnectionFactoryProvider implements ConnectionFactoryProvi
         return false;
     }
 
+    @Override
+    public String getDriver() {
+        return H2_DRIVER;
+    }
 }

--- a/src/test/java/io/r2dbc/h2/H2ConnectionFactoryProviderTest.java
+++ b/src/test/java/io/r2dbc/h2/H2ConnectionFactoryProviderTest.java
@@ -69,4 +69,9 @@ final class H2ConnectionFactoryProviderTest {
             .option(URL, "test-url")
             .build())).isTrue();
     }
+
+    @Test
+    void returnsDriverIdentifier() {
+        assertThat(this.provider.getDriver()).isEqualTo(H2_DRIVER);
+    }
 }


### PR DESCRIPTION
getDriver() returns the driver identifier h2.

[resolves #48]