### PR TITLE
URL Cleanup

### DIFF
--- a/src/main/java/io/r2dbc/h2/H2ConnectionConfiguration.java
+++ b/src/main/java/io/r2dbc/h2/H2ConnectionConfiguration.java
@@ -156,7 +156,7 @@ public final class H2ConnectionConfiguration {
          * Configure the database url. Includes everything after the {@code jdbc:h2:} prefix. For in-memory and file-based databases, must include the proper prefix (e.g. {@code file:} or {@code
          * mem:}).
          * <p>
-         * See <a href="http://www.h2database.com/html/features.html#database_url">http://www.h2database.com/html/features.html#database_url</a> for more details.
+         * See <a href="https://www.h2database.com/html/features.html#database_url">https://www.h2database.com/html/features.html#database_url</a> for more details.
          *
          * @param url the url
          * @return this {@link Builder}


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.h2database.com/html/features.html with 2 occurrences migrated to:  
  https://www.h2database.com/html/features.html ([https](https://www.h2database.com/html/features.html) result 200).