### PR TITLE
Use reactor-extra for tests only

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
         <dependency>
             <groupId>io.projectreactor.addons</groupId>
             <artifactId>reactor-extra</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.r2dbc</groupId>

--- a/src/main/java/io/r2dbc/h2/H2Result.java
+++ b/src/main/java/io/r2dbc/h2/H2Result.java
@@ -31,8 +31,6 @@ import reactor.util.annotation.Nullable;
 
 import java.util.function.BiFunction;
 
-import static reactor.function.TupleUtils.function;
-
 /**
  * An implementation of {@link Result} representing the results of a query against an H2 database.
  */
@@ -61,7 +59,7 @@ public final class H2Result implements Result {
 
         return this.rows
             .zipWith(this.rowMetadata.repeat())
-            .map(function(f::apply));
+            .map(tuple -> f.apply(tuple.getT1(), tuple.getT2()));
     }
 
     @Override


### PR DESCRIPTION
As a low level library, I think `r2dbc-h2` should limit its dependencies. See related https://github.com/r2dbc/r2dbc-postgresql/pull/96.