### PR TITLE
Add factory method to create in-memory databases

### DIFF
--- a/src/main/java/io/r2dbc/h2/CloseableConnectionFactory.java
+++ b/src/main/java/io/r2dbc/h2/CloseableConnectionFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.h2;
+
+import io.r2dbc.spi.Closeable;
+import io.r2dbc.spi.ConnectionFactory;
+import reactor.core.publisher.Mono;
+
+/**
+ * Union-interface combining {@link ConnectionFactory} and {@link Closeable} for {@link H2Connection}.
+ * <p>Closing this {@link ConnectionFactory} invalidates all open {@link H2Connection}s and {@link #create() connection creation} is no longer possible.
+ */
+public interface CloseableConnectionFactory extends ConnectionFactory, Closeable {
+
+    @Override
+    Mono<H2Connection> create();
+
+    @Override
+    Mono<Void> close();
+}

--- a/src/main/java/io/r2dbc/h2/H2ConnectionConfiguration.java
+++ b/src/main/java/io/r2dbc/h2/H2ConnectionConfiguration.java
@@ -30,7 +30,7 @@ import java.util.Optional;
  */
 public final class H2ConnectionConfiguration {
 
-    private final String password;
+    private final CharSequence password;
 
     private final String url;
 
@@ -38,7 +38,7 @@ public final class H2ConnectionConfiguration {
 
     private final Map<String, String> properties;
 
-    private H2ConnectionConfiguration(@Nullable String password, String url, @Nullable String username, Map<String, String> properties) {
+    private H2ConnectionConfiguration(@Nullable CharSequence password, String url, @Nullable String username, Map<String, String> properties) {
         this.password = password;
         this.url = Assert.requireNonNull(url, "url must not be null");
         this.username = username;
@@ -57,14 +57,14 @@ public final class H2ConnectionConfiguration {
     @Override
     public String toString() {
         return "H2ConnectionConfiguration{" +
-            "password='" + this.password + '\'' +
+            "password='REDACTED'" +
             ", properties='" + this.properties + '\'' +
             ", url='" + this.url + '\'' +
             ", username='" + this.username + '\'' +
             '}';
     }
 
-    Optional<String> getPassword() {
+    Optional<CharSequence> getPassword() {
         return Optional.ofNullable(this.password);
     }
 
@@ -91,7 +91,7 @@ public final class H2ConnectionConfiguration {
 
         private Map<String, String> properties = new LinkedHashMap<>();
 
-        private String password;
+        private CharSequence password;
 
         private String url;
 
@@ -197,7 +197,7 @@ public final class H2ConnectionConfiguration {
          * @param password the password
          * @return this {@link Builder}
          */
-        public Builder password(@Nullable String password) {
+        public Builder password(@Nullable CharSequence password) {
             this.password = password;
             return this;
         }
@@ -205,7 +205,7 @@ public final class H2ConnectionConfiguration {
         @Override
         public String toString() {
             return "Builder{" +
-                "password='" + this.password + '\'' +
+                "password='REDACTED'" +
                 ", properties='" + this.properties + '\'' +
                 ", url='" + this.url + '\'' +
                 ", username='" + this.username + '\'' +

--- a/src/main/java/io/r2dbc/h2/H2DatabaseExceptionFactory.java
+++ b/src/main/java/io/r2dbc/h2/H2DatabaseExceptionFactory.java
@@ -136,4 +136,11 @@ public final class H2DatabaseExceptionFactory {
         }
     }
 
+    static class H2R2dbcNonTransientResourceException extends R2dbcNonTransientResourceException {
+
+        public H2R2dbcNonTransientResourceException(String reason) {
+            super(reason);
+        }
+    }
+
 }

--- a/src/test/java/io/r2dbc/h2/H2ConnectionFactoryInMemoryTest.java
+++ b/src/test/java/io/r2dbc/h2/H2ConnectionFactoryInMemoryTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.h2;
+
+import io.r2dbc.spi.ConnectionFactory;
+import io.r2dbc.spi.R2dbcNonTransientResourceException;
+import io.r2dbc.spi.Result;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.UUID;
+
+final class H2ConnectionFactoryInMemoryTest {
+
+    @Test
+    void shouldCreateInMemoryDatabase() {
+
+        CloseableConnectionFactory connectionFactory = H2ConnectionFactory.inMemory(UUID.randomUUID().toString());
+
+        connectionFactory.create().flatMapMany(H2Connection::close).as(StepVerifier::create).verifyComplete();
+    }
+
+    @Test
+    void retainsStateAfterRunningCommand() {
+
+        CloseableConnectionFactory connectionFactory = H2ConnectionFactory.inMemory(UUID.randomUUID().toString());
+
+        runCommand(connectionFactory, "CREATE TABLE lego (id INT);");
+        runCommand(connectionFactory, "INSERT INTO lego VALUES(42);");
+    }
+
+    @Test
+    void databaseClosedAfterFactoryClose() {
+
+        String database = UUID.randomUUID().toString();
+        CloseableConnectionFactory connectionFactory = H2ConnectionFactory.inMemory(database);
+
+        runCommand(connectionFactory, "CREATE TABLE lego (id INT);");
+
+        connectionFactory.close().as(StepVerifier::create).verifyComplete();
+
+        CloseableConnectionFactory nextInstance = H2ConnectionFactory.inMemory(database);
+        runCommand(nextInstance, "CREATE TABLE lego (id INT);");
+    }
+
+    @Test
+    void closedDatabaseFailsToCreateConnections() {
+
+        String database = UUID.randomUUID().toString();
+        CloseableConnectionFactory connectionFactory = H2ConnectionFactory.inMemory(database);
+
+        runCommand(connectionFactory, "CREATE TABLE lego (id INT);");
+
+        connectionFactory.close().as(StepVerifier::create).verifyComplete();
+        connectionFactory.create().as(StepVerifier::create).verifyError(R2dbcNonTransientResourceException.class);
+    }
+
+    @Test
+    void closedDatabaseShutsDownClientSessions() {
+
+        String database = UUID.randomUUID().toString();
+        CloseableConnectionFactory connectionFactory = H2ConnectionFactory.inMemory(database);
+
+        H2Connection userSession = connectionFactory.create().block();
+
+        connectionFactory.close().as(StepVerifier::create).verifyComplete();
+
+        userSession.createStatement("CREATE TABLE lego (id INT);").execute().as(StepVerifier::create).verifyError(R2dbcNonTransientResourceException.class);
+    }
+
+    static void runCommand(ConnectionFactory connectionFactory, String sql) {
+
+        Mono.from(connectionFactory.create()).flatMapMany(it -> {
+            return Flux.from(it.createStatement(sql).execute()).flatMap(Result::getRowsUpdated).thenMany(it.close());
+        }).as(StepVerifier::create)
+            .verifyComplete();
+    }
+}

--- a/src/test/java/io/r2dbc/h2/H2ConnectionIntegrationTest.java
+++ b/src/test/java/io/r2dbc/h2/H2ConnectionIntegrationTest.java
@@ -33,7 +33,7 @@ final class H2ConnectionIntegrationTest {
     void getMetadata() {
 
         ConnectionInfo configuration = new ConnectionInfo("jdbc:h2:mem:" + UUID.randomUUID().toString() + ";USER=sa;PASSWORD=sa;", new Properties());
-        SessionClient sessionClient = new SessionClient(configuration);
+        SessionClient sessionClient = new SessionClient(configuration, false);
 
         H2Connection connection = new H2Connection(sessionClient, new DefaultCodecs(sessionClient));
         H2ConnectionMetadata metadata = connection.getMetadata();


### PR DESCRIPTION
`H2ConnectionFactory` now provides `inMemory(…) `methods to create a managed in-memory database instance. The resulting `ConnectionFactory` is closeable to allow a clean shutdown of the database once the `ConnectionFactory` is no longer in use.

Databases created via `inMemory(…)` are kept open and do not require setting `DB_CLOSE_DELAY` or `DB_CLOSE_ON_EXIT` options.

/cc @odrotbohm as you were involved in #55.