### PR TITLE
Remove GeometryCodec from default codec list.

### DIFF
--- a/src/main/java/io/r2dbc/h2/codecs/DefaultCodecs.java
+++ b/src/main/java/io/r2dbc/h2/codecs/DefaultCodecs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,6 @@ public final class DefaultCodecs implements Codecs {
                 new ClobCodec(client),
                 new DoubleCodec(),
                 new FloatCodec(),
-                new GeometryCodec(),
                 new IntegerCodec(),
                 new LocalDateCodec(),
                 new LocalDateTimeCodec(),


### PR DESCRIPTION
`GeometryCodec` is an optional codec and must not be added to the list of default codecs as the JTS topology suite is a provided dependency only.

The current snapshot build breaks our SDN/RX (https://github.com/neo4j/sdn-rx) builds, as we use r2dbc-h2 and its reactive transaction manager to test our integration with other transaction manager (see https://github.com/neo4j/sdn-rx/blob/master/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/transaction/ReactiveNeo4jTransactionManagerTest.java#L145).