### PR TITLE
Fix ClobToStringCodec.encode and simplify decode

### DIFF
--- a/src/test/java/io/r2dbc/h2/codecs/ClobCodecTest.java
+++ b/src/test/java/io/r2dbc/h2/codecs/ClobCodecTest.java
@@ -25,18 +25,20 @@ import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
+import java.nio.charset.StandardCharsets;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.Mockito.mock;
 
 final class ClobCodecTest {
 
-    String TEST = "foo你好";
-    byte[] TEST_BYTES = TEST.getBytes();
+    String TEST = "hello你好こんにちはアロハ안녕하세요Здравствуйте";
+    byte[] TEST_BYTES = TEST.getBytes(StandardCharsets.UTF_8);
 
     @Test
     void decode() {
-        Flux.from(new ClobCodec(mock(Client.class)).decode(ValueLobDb.createSmallLob(Value.BLOB , TEST_BYTES), Clob.class).stream())
+        Flux.from(new ClobCodec(mock(Client.class)).decode(ValueLobDb.createSmallLob(Value.CLOB , TEST_BYTES), Clob.class).stream())
             .as(StepVerifier::create)
             .expectNext(TEST)
             .verifyComplete();


### PR DESCRIPTION
Issue description
---

See also #127 .

We need the blocking results with `doEncode` and `doDecode`, so we can just use the blocking methods, like `Value.getString()` or `new XxxReader(someString)`.

Additional context
---

- Correct value type and charset in the test case of `ClobCodecTest`
  - Value type should be `CLOB` instead of `BLOB`
  - See also the source code of `ValueLobDb.createSmallLob` and `ValueLobDb.getString`, they are using `StandardCharsets.UTF_8`
- Add more characters into the test case of `ClobCodecTest`
