### PR TITLE
Update README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -78,7 +78,7 @@ Mono<Connection> connectionMono = Mono.from(connectionFactory.create());
 | `port`            | Only for `tcp` protocol: Server port to connect to. _(Optional)_
 | `username`        | Login username.
 | `password`        | Login password.
-| `database`        | Database to use. For `file` protocol: Relative (`r2dbc:h2:file//../relative/file/name`) or absolute (`r2dbc:h2:file///absolute/file/name`) file name. For `mem` protocol: In-memory database name (`r2dbc:h2:mem:///testdb`).
+| `database`        | Database to use. For `file` protocol: Relative (`r2dbc:h2:file//../relative/file/name`) or absolute (`r2dbc:h2:file:///absolute/file/name`) file name. For `mem` protocol: In-memory database name (`r2dbc:h2:mem:///testdb`).
 | `<well-known-h2-option>`         | Pass-thru of well-known H2 options such as `DB_CLOSE_DELAY=10&MODE=DB2`. See https://github.com/r2dbc/r2dbc-h2/blob/main/src/main/java/io/r2dbc/h2/H2ConnectionOption.java[`io.r2dbc.h2.H2ConnectionOption`] for all options. _(Optional)_
 | `options`         | A semicolon-delimited list of H2 configuration options(`options=DB_CLOSE_DELAY=10;DB_CLOSE_ON_EXIT=true;…)`. _(Optional)_
 |===


### PR DESCRIPTION
Missing semi-colon on r2dbc H2 file database URL

<!-- First of all: Have you checked the docs, GitHub issues, or Stack Overflow whether someone else has already reported your issue? -->

Make sure that:

- [ ] You have read the [contribution guidelines](https://github.com/r2dbc/.github/blob/main/CONTRIBUTING.adoc).
- [ ] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [ ] You use the code formatters provided [here](https://github.com/r2dbc/.github/blob/main/intellij-style.xml) and have them applied to your changes. Don't submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

#### Issue description

<!-- A clear and concise description of the issue or link to a GitHub issue #.-->
 
#### New Public APIs

<!--- List any new public APIs added with this Fix. --->

#### Additional context

<!-- Add any other context about the problem here. Do not add code as screenshots. -->
