### PR TITLE
Fix BlobCodec/ClobCodec encode blocking on NonBlocking threads

### DIFF
--- a/src/main/java/io/r2dbc/h2/H2Statement.java
+++ b/src/main/java/io/r2dbc/h2/H2Statement.java
@@ -20,6 +20,9 @@ import io.r2dbc.h2.client.Binding;
 import io.r2dbc.h2.client.Client;
 import io.r2dbc.h2.codecs.Codecs;
 import io.r2dbc.h2.util.Assert;
+import io.r2dbc.spi.Blob;
+import io.r2dbc.spi.Clob;
+import io.r2dbc.spi.Parameter;
 import io.r2dbc.spi.Statement;
 import org.h2.command.CommandInterface;
 import org.h2.engine.GeneratedKeysMode;
@@ -113,8 +116,13 @@ public final class H2Statement implements Statement {
     }
 
     Flux<H2Result> doExecute(String sql, Bindings bindings) {
-        return Flux.fromIterable(() -> this.client.prepareCommand(sql, bindings.bindings))
-            .flatMap(it -> execute(it, this.client, this.codecs, this.generatedColumns == null ? this.allGeneratedColumns : this.generatedColumns));
+        // Resolve deferred LOB parameters (Blob/Clob streams) before preparing H2 commands.
+        // See https://github.com/r2dbc/r2dbc-h2/issues/129
+        return Flux.fromIterable(bindings.bindings)
+            .concatMap(Binding::resolve)
+            .collectList()
+            .flatMapMany(resolved -> Flux.fromIterable(() -> this.client.prepareCommand(sql, resolved))
+                .flatMap(it -> execute(it, this.client, this.codecs, this.generatedColumns == null ? this.allGeneratedColumns : this.generatedColumns)));
     }
 
     @Override
@@ -138,9 +146,27 @@ public final class H2Statement implements Statement {
         Assert.requireNonNull(value, "value must not be null");
 
         this.bindings.open = false;
-        this.bindings.getCurrent().add(index, this.codecs.encode(value));
+
+        // Defer Blob/Clob stream consumption until execute (issue #129). Binding on a
+        // NonBlocking Reactor thread must not call Flux.toIterable()/block().
+        if (requiresReactiveEncoding(value)) {
+            this.bindings.getCurrent().add(index, this.codecs.encodeReactive(value));
+        } else {
+            this.bindings.getCurrent().add(index, this.codecs.encode(value));
+        }
 
         return this;
+    }
+
+    private static boolean requiresReactiveEncoding(Object value) {
+        Object effective = value;
+        if (value instanceof Parameter) {
+            effective = ((Parameter) value).getValue();
+            if (effective == null) {
+                return false;
+            }
+        }
+        return effective instanceof Blob || effective instanceof Clob;
     }
 
     private static Mono<H2Result> execute(CommandInterface command, Client client, Codecs codecs, Object generatedColumns) {

--- a/src/main/java/io/r2dbc/h2/client/Binding.java
+++ b/src/main/java/io/r2dbc/h2/client/Binding.java
@@ -18,6 +18,10 @@ package io.r2dbc.h2.client;
 
 import io.r2dbc.h2.util.Assert;
 import org.h2.value.Value;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.util.function.Tuple2;
+import reactor.util.function.Tuples;
 
 import java.util.Objects;
 import java.util.SortedMap;
@@ -25,12 +29,17 @@ import java.util.TreeMap;
 
 /**
  * A collection of {@link Value}s for a single bind invocation of an {@link Client}.
+ * <p>
+ * Parameters may be bound immediately as {@link Value}s or deferred as {@link Mono}s
+ * (for example LOB streams that must not be consumed until statement execution).
  */
 public final class Binding {
 
     static final Binding EMPTY = new Binding();
 
     private final SortedMap<Integer, Value> parameters = new TreeMap<>();
+
+    private final SortedMap<Integer, Mono<Value>> deferredParameters = new TreeMap<>();
 
     /**
      * Add a {@link Value} to the binding.
@@ -45,8 +54,60 @@ public final class Binding {
         Assert.requireNonNull(value, "value must not be null");
 
         this.parameters.put(index, value);
+        this.deferredParameters.remove(index);
 
         return this;
+    }
+
+    /**
+     * Add a deferred {@link Value} publisher to the binding. The publisher is not
+     * subscribed until {@link #resolve()} is called (during statement execution).
+     *
+     * @param index the index of the parameter
+     * @param value the deferred {@link Value}
+     * @return this {@link Binding}
+     * @throws NullPointerException if {@code index} or {@code value} is {@code null}
+     */
+    public Binding add(Integer index, Mono<Value> value) {
+        Assert.requireNonNull(index, "index must not be null");
+        Assert.requireNonNull(value, "value must not be null");
+
+        this.deferredParameters.put(index, value);
+        this.parameters.remove(index);
+
+        return this;
+    }
+
+    /**
+     * Resolve deferred parameters into concrete {@link Value}s.
+     *
+     * @return a mono emitting a binding that contains only resolved {@link Value}s
+     */
+    public Mono<Binding> resolve() {
+        if (this.deferredParameters.isEmpty()) {
+            return Mono.just(this);
+        }
+
+        return Flux.fromIterable(this.deferredParameters.entrySet())
+            .concatMap(entry -> entry.getValue().map(value -> Tuples.of(entry.getKey(), value)))
+            .collectList()
+            .map(resolved -> {
+                Binding binding = new Binding();
+                this.parameters.forEach(binding::add);
+                for (Tuple2<Integer, Value> tuple : resolved) {
+                    binding.add(tuple.getT1(), tuple.getT2());
+                }
+                return binding;
+            });
+    }
+
+    /**
+     * Whether this binding still has unresolved deferred parameters.
+     *
+     * @return {@code true} if deferred parameters remain
+     */
+    public boolean hasDeferredParameters() {
+        return !this.deferredParameters.isEmpty();
     }
 
     @Override
@@ -58,18 +119,20 @@ public final class Binding {
             return false;
         }
         Binding that = (Binding) o;
-        return Objects.equals(this.parameters, that.parameters);
+        return Objects.equals(this.parameters, that.parameters)
+            && Objects.equals(this.deferredParameters.keySet(), that.deferredParameters.keySet());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.parameters);
+        return Objects.hash(this.parameters, this.deferredParameters.keySet());
     }
 
     @Override
     public String toString() {
         return "Binding{" +
             "parameters=" + this.parameters +
+            ", deferredParameters=" + this.deferredParameters.keySet() +
             '}';
     }
 

--- a/src/main/java/io/r2dbc/h2/codecs/BlobCodec.java
+++ b/src/main/java/io/r2dbc/h2/codecs/BlobCodec.java
@@ -23,12 +23,12 @@ import org.h2.value.Value;
 import org.h2.value.ValueBlob;
 import org.h2.value.ValueNull;
 import reactor.core.publisher.Flux;
-import reactor.core.scheduler.Schedulers;
+import reactor.core.publisher.Mono;
 
-import java.io.InputStream;
-import java.io.SequenceInputStream;
-import java.util.Enumeration;
-import java.util.Iterator;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
 
 final class BlobCodec extends AbstractCodec<Blob> {
 
@@ -55,41 +55,48 @@ final class BlobCodec extends AbstractCodec<Blob> {
 
     @Override
     Value doEncode(Blob value) {
-        Assert.requireNonNull(value, "value must not be null");
-
-        ValueBlob blob = this.client.getSession().getDataHandler().getLobStorage().createBlob(
-            new SequenceInputStream(
-                new BlobInputStreamEnumeration(value)), -1);
-
-        this.client.getSession().addTemporaryLob(blob);
-
-        return blob;
+        return encodeReactive(value).block();
     }
 
     /**
-     * Converts a {@link Flux} of {@link Blob}s into an {@link Enumeration} of {@link InputStream}s.
+     * Encode a {@link Blob} by materializing its stream reactively.
+     * Does not block; consumption is deferred until the returned {@link Mono} is subscribed
+     * (typically during statement execution).
+     *
+     * @param value the blob to encode
+     * @return a mono emitting the H2 value
      */
-    private final class BlobInputStreamEnumeration implements Enumeration<InputStream> {
+    Mono<Value> encodeReactive(Blob value) {
+        Assert.requireNonNull(value, "value must not be null");
 
-        private final Iterator<ByteBufferInputStream> inputStreams;
+        return Flux.from(value.stream())
+            .reduceWith(ByteArrayOutputStream::new, BlobCodec::write)
+            .map(out -> {
+                ValueBlob blob = this.client.getSession().getDataHandler().getLobStorage().createBlob(
+                    new ByteArrayInputStream(out.toByteArray()), out.size());
 
-        BlobInputStreamEnumeration(Blob value) {
-            this.inputStreams = Flux.from(value.stream())
-                .map(ByteBufferInputStream::new)
-                .subscribeOn(Schedulers.boundedElastic())
-                .cancelOn(Schedulers.boundedElastic())
-                .toIterable()
-                .iterator();
-        }
+                this.client.getSession().addTemporaryLob(blob);
 
-        @Override
-        public boolean hasMoreElements() {
-            return inputStreams.hasNext();
-        }
+                return (Value) blob;
+            })
+            .flatMap(encoded -> Mono.from(value.discard())
+                .onErrorResume(e -> Mono.empty())
+                .thenReturn(encoded));
+    }
 
-        @Override
-        public InputStream nextElement() {
-            return inputStreams.next();
+    private static ByteArrayOutputStream write(ByteArrayOutputStream out, ByteBuffer buffer) {
+        try {
+            if (buffer.hasArray()) {
+                out.write(buffer.array(), buffer.arrayOffset() + buffer.position(), buffer.remaining());
+                buffer.position(buffer.limit());
+            } else {
+                byte[] bytes = new byte[buffer.remaining()];
+                buffer.get(bytes);
+                out.write(bytes);
+            }
+            return out;
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to materialize Blob stream", e);
         }
     }
 

--- a/src/main/java/io/r2dbc/h2/codecs/BlobToByteBufferCodec.java
+++ b/src/main/java/io/r2dbc/h2/codecs/BlobToByteBufferCodec.java
@@ -18,18 +18,12 @@ package io.r2dbc.h2.codecs;
 
 import io.r2dbc.h2.client.Client;
 import io.r2dbc.h2.util.Assert;
-import io.r2dbc.spi.Blob;
 import org.h2.value.Value;
 import org.h2.value.ValueBlob;
 import org.h2.value.ValueNull;
-import reactor.core.publisher.Flux;
-import reactor.core.scheduler.Schedulers;
 
-import java.io.InputStream;
-import java.io.SequenceInputStream;
+import java.io.ByteArrayInputStream;
 import java.nio.ByteBuffer;
-import java.util.Enumeration;
-import java.util.Iterator;
 
 final class BlobToByteBufferCodec extends AbstractCodec<ByteBuffer> {
 
@@ -63,39 +57,15 @@ final class BlobToByteBufferCodec extends AbstractCodec<ByteBuffer> {
     Value doEncode(ByteBuffer value) {
         Assert.requireNonNull(value, "value must not be null");
 
+        ByteBuffer buffer = value.duplicate();
+        byte[] bytes = new byte[buffer.remaining()];
+        buffer.get(bytes);
+
         ValueBlob blob = this.client.getSession().getDataHandler().getLobStorage().createBlob(
-            new SequenceInputStream(
-                new BlobInputStreamEnumeration(value)), -1);
+            new ByteArrayInputStream(bytes), bytes.length);
 
         this.client.getSession().addTemporaryLob(blob);
 
         return blob;
-    }
-
-    /**
-     * Converts a {@link Flux} of {@link Blob}s into an {@link Enumeration} of {@link InputStream}s.
-     */
-    private final class BlobInputStreamEnumeration implements Enumeration<InputStream> {
-
-        private final Iterator<ByteBufferInputStream> inputStreams;
-
-        BlobInputStreamEnumeration(ByteBuffer value) {
-            this.inputStreams = Flux.just(value)
-                .map(ByteBufferInputStream::new)
-                .subscribeOn(Schedulers.boundedElastic())
-                .cancelOn(Schedulers.boundedElastic())
-                .toIterable()
-                .iterator();
-        }
-
-        @Override
-        public boolean hasMoreElements() {
-            return inputStreams.hasNext();
-        }
-
-        @Override
-        public InputStream nextElement() {
-            return inputStreams.next();
-        }
     }
 }

--- a/src/main/java/io/r2dbc/h2/codecs/ClobCodec.java
+++ b/src/main/java/io/r2dbc/h2/codecs/ClobCodec.java
@@ -23,12 +23,9 @@ import org.h2.value.Value;
 import org.h2.value.ValueClob;
 import org.h2.value.ValueNull;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
-import java.io.CharArrayReader;
-import java.io.IOException;
-import java.io.Reader;
-import java.nio.CharBuffer;
-import java.util.Iterator;
+import java.io.StringReader;
 
 final class ClobCodec extends AbstractCodec<Clob> {
 
@@ -55,62 +52,34 @@ final class ClobCodec extends AbstractCodec<Clob> {
 
     @Override
     Value doEncode(Clob value) {
-        Assert.requireNonNull(value, "value must not be null");
-
-        ValueClob clob = this.client.getSession().getDataHandler().getLobStorage().createClob(
-            new AggregateCharArrayReader(value), -1);
-
-        this.client.getSession().addTemporaryLob(clob);
-
-        return clob;
+        return encodeReactive(value).block();
     }
 
     /**
-     * Converts a {@link Flux} of {@link Clob}s into a {@link Reader} of {@link CharArrayReader}s.
+     * Encode a {@link Clob} by materializing its stream reactively.
+     * Does not block; consumption is deferred until the returned {@link Mono} is subscribed
+     * (typically during statement execution).
+     *
+     * @param value the clob to encode
+     * @return a mono emitting the H2 value
      */
-    private final class AggregateCharArrayReader extends Reader {
+    Mono<Value> encodeReactive(Clob value) {
+        Assert.requireNonNull(value, "value must not be null");
 
-        private final Iterator<CharArrayReader> readers;
+        return Flux.from(value.stream())
+            .reduceWith(StringBuilder::new, StringBuilder::append)
+            .map(sb -> {
+                String content = sb.toString();
+                ValueClob clob = this.client.getSession().getDataHandler().getLobStorage().createClob(
+                    new StringReader(content), content.length());
 
-        private CharArrayReader current;
+                this.client.getSession().addTemporaryLob(clob);
 
-        private AggregateCharArrayReader(Clob value) {
-            this.readers = Flux.from(value.stream())
-                .map(CharBuffer::wrap)
-                .map(charBuffer -> {
-                    if (charBuffer.hasArray()) {
-                        return charBuffer.array();
-                    } else {
-                        return charBuffer.toString().toCharArray();
-                    }
-                })
-                .map(CharArrayReader::new)
-                .toIterable()
-                .iterator();
-
-            if (this.readers.hasNext()) {
-                this.current = this.readers.next();
-            }
-
-        }
-
-        @Override
-        public int read(char[] cbuf, int off, int len) throws IOException {
-            int results = this.current.read(cbuf, off, len);
-
-            if (results == -1) {
-                if (this.readers.hasNext()) {
-                    this.current = this.readers.next();
-                    return read(cbuf, off, len);
-                }
-            }
-
-            return results;
-        }
-
-        @Override
-        public void close() {
-            this.current.close();
-        }
+                return (Value) clob;
+            })
+            .flatMap(encoded -> Mono.from(value.discard())
+                .onErrorResume(e -> Mono.empty())
+                .thenReturn(encoded));
     }
+
 }

--- a/src/main/java/io/r2dbc/h2/codecs/Codecs.java
+++ b/src/main/java/io/r2dbc/h2/codecs/Codecs.java
@@ -17,6 +17,7 @@
 package io.r2dbc.h2.codecs;
 
 import org.h2.value.Value;
+import reactor.core.publisher.Mono;
 import reactor.util.annotation.Nullable;
 
 /**
@@ -45,6 +46,17 @@ public interface Codecs {
      * @throws NullPointerException if {@code value} is {@code null}
      */
     Value encode(Object value);
+
+    /**
+     * Encode a value, deferring consumption of reactive sources (for example
+     * {@link io.r2dbc.spi.Blob} / {@link io.r2dbc.spi.Clob} streams) until the
+     * returned {@link Mono} is subscribed.
+     *
+     * @param value the value to encode
+     * @return a mono emitting the encoded value
+     * @throws NullPointerException if {@code value} is {@code null}
+     */
+    Mono<Value> encodeReactive(Object value);
 
     /**
      * Encode a {@code null} value.

--- a/src/main/java/io/r2dbc/h2/codecs/DefaultCodecs.java
+++ b/src/main/java/io/r2dbc/h2/codecs/DefaultCodecs.java
@@ -18,8 +18,12 @@ package io.r2dbc.h2.codecs;
 
 import io.r2dbc.h2.client.Client;
 import io.r2dbc.h2.util.Assert;
+import io.r2dbc.spi.Blob;
+import io.r2dbc.spi.Clob;
+import io.r2dbc.spi.Parameter;
 import org.h2.value.Value;
 import org.h2.value.ValueNull;
+import reactor.core.publisher.Mono;
 import reactor.util.annotation.Nullable;
 
 import java.util.List;
@@ -72,6 +76,37 @@ public final class DefaultCodecs implements Codecs {
         }
 
         throw new IllegalArgumentException(String.format("Cannot encode parameter of type %s", value.getClass().getName()));
+    }
+
+    @Override
+    public Mono<Value> encodeReactive(Object value) {
+        Assert.requireNonNull(value, "value must not be null");
+
+        if (value instanceof Parameter) {
+            Parameter parameter = (Parameter) value;
+            if (parameter.getValue() == null) {
+                return Mono.just(encodeNull(parameter.getType().getJavaType()));
+            }
+            return encodeReactive(parameter.getValue());
+        }
+
+        if (value instanceof Blob) {
+            for (Codec<?> codec : this.codecs) {
+                if (codec instanceof BlobCodec && codec.canEncode(value)) {
+                    return ((BlobCodec) codec).encodeReactive((Blob) value);
+                }
+            }
+        }
+
+        if (value instanceof Clob) {
+            for (Codec<?> codec : this.codecs) {
+                if (codec instanceof ClobCodec && codec.canEncode(value)) {
+                    return ((ClobCodec) codec).encodeReactive((Clob) value);
+                }
+            }
+        }
+
+        return Mono.fromCallable(() -> encode(value));
     }
 
     @Override

--- a/src/test/java/io/r2dbc/h2/H2LobIntegrationTest.java
+++ b/src/test/java/io/r2dbc/h2/H2LobIntegrationTest.java
@@ -25,12 +25,14 @@ import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Hooks;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Optional;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -182,6 +184,84 @@ class H2LobIntegrationTest extends IntegrationTestSupport {
             .as(StepVerifier::create)
             .expectNext(i * TEST_STRING.length())
             .verifyComplete();
+    }
+
+    /**
+     * Regression for {@code #129}: binding a Blob on a NonBlocking Reactor thread must not
+     * throw {@link IllegalStateException} from {@code toIterable()}/blocking stream consumption.
+     */
+    @Test
+    void testSmallBlobBindOnParallelScheduler() {
+        createTable(connection, "IMAGE");
+
+        Flux.defer(() -> Flux.from(connection.createStatement("INSERT INTO lob_test values($1)")
+                .bind("$1", Blob.from(Mono.just(ByteBuffer.wrap("foo".getBytes()))))
+                .execute()))
+            .subscribeOn(Schedulers.parallel())
+            .flatMap(Result::getRowsUpdated)
+            .as(StepVerifier::create)
+            .expectNext(1L)
+            .verifyComplete();
+
+        connection.createStatement("SELECT my_col FROM lob_test")
+            .execute()
+            .flatMap(it -> it.map((row, rowMetadata) -> row.get("my_col", Blob.class)))
+            .flatMap(Blob::stream)
+            .as(StepVerifier::create)
+            .consumeNextWith(actual -> assertThat(actual).isEqualTo(ByteBuffer.wrap("foo".getBytes())))
+            .verifyComplete();
+    }
+
+    /**
+     * Regression for {@code #129}: binding a Clob on a NonBlocking Reactor thread.
+     */
+    @Test
+    void testClobBindOnParallelScheduler() {
+        createTable(connection, "CLOB");
+
+        Flux.defer(() -> Flux.from(connection.createStatement("INSERT INTO lob_test values($1)")
+                .bind("$1", Clob.from(Mono.just("foo你好")))
+                .execute()))
+            .subscribeOn(Schedulers.parallel())
+            .flatMap(Result::getRowsUpdated)
+            .as(StepVerifier::create)
+            .expectNext(1L)
+            .verifyComplete();
+
+        connection.createStatement("SELECT my_col FROM lob_test")
+            .execute()
+            .flatMap(it -> it.map((row, rowMetadata) -> row.get("my_col", Clob.class)))
+            .flatMap(Clob::stream)
+            .as(StepVerifier::create)
+            .consumeNextWith(actual -> assertThat(actual).isEqualTo("foo你好"))
+            .verifyComplete();
+    }
+
+    /**
+     * Binding a Blob must not subscribe to the LOB publisher until {@code execute()}.
+     */
+    @Test
+    void testBlobStreamDeferredUntilExecute() {
+        createTable(connection, "IMAGE");
+
+        AtomicBoolean subscribed = new AtomicBoolean();
+        Blob blob = Blob.from(Flux.defer(() -> {
+            subscribed.set(true);
+            return Flux.just(ByteBuffer.wrap("foo".getBytes()));
+        }));
+
+        H2Statement statement = (H2Statement) connection.createStatement("INSERT INTO lob_test values($1)")
+            .bind("$1", blob);
+
+        assertThat(subscribed).isFalse();
+
+        Flux.from(statement.execute())
+            .flatMap(Result::getRowsUpdated)
+            .as(StepVerifier::create)
+            .expectNext(1L)
+            .verifyComplete();
+
+        assertThat(subscribed).isTrue();
     }
 
     private void createTable(H2Connection connection, String columnType) {

--- a/src/test/java/io/r2dbc/h2/client/BindingTest.java
+++ b/src/test/java/io/r2dbc/h2/client/BindingTest.java
@@ -16,9 +16,13 @@
 
 package io.r2dbc.h2.client;
 
+import org.h2.value.Value;
 import org.h2.value.ValueInteger;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 final class BindingTest {
@@ -31,8 +35,32 @@ final class BindingTest {
 
     @Test
     void addNoValue() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new Binding().add(1, null))
+        assertThatIllegalArgumentException().isThrownBy(() -> new Binding().add(1, (Value) null))
             .withMessage("value must not be null");
+    }
+
+    @Test
+    void addNoDeferredValue() {
+        assertThatIllegalArgumentException().isThrownBy(() -> new Binding().add(1, (Mono<Value>) null))
+            .withMessage("value must not be null");
+    }
+
+    @Test
+    void resolveDeferredParameters() {
+        Binding binding = new Binding()
+            .add(0, ValueInteger.get(1))
+            .add(1, Mono.just(ValueInteger.get(2)));
+
+        assertThat(binding.hasDeferredParameters()).isTrue();
+
+        binding.resolve()
+            .as(StepVerifier::create)
+            .assertNext(resolved -> {
+                assertThat(resolved.hasDeferredParameters()).isFalse();
+                assertThat(resolved.getParameters()).containsEntry(0, ValueInteger.get(1));
+                assertThat(resolved.getParameters()).containsEntry(1, ValueInteger.get(2));
+            })
+            .verifyComplete();
     }
 
 }

--- a/src/test/java/io/r2dbc/h2/codecs/BlobCodecTest.java
+++ b/src/test/java/io/r2dbc/h2/codecs/BlobCodecTest.java
@@ -18,22 +18,61 @@ package io.r2dbc.h2.codecs;
 
 import io.r2dbc.h2.client.Client;
 import io.r2dbc.spi.Blob;
+import org.h2.engine.Session;
+import org.h2.store.DataHandler;
+import org.h2.store.LobStorageInterface;
 import org.h2.value.Value;
 import org.h2.value.ValueBlob;
 import org.h2.value.ValueNull;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 
+import java.io.InputStream;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 final class BlobCodecTest {
 
     byte[] TEST_BYTES = "Hello".getBytes();
+
+    private Client client;
+
+    private LobStorageInterface lobStorage;
+
+    @BeforeEach
+    void setUp() {
+        this.client = mock(Client.class);
+        Session session = mock(Session.class);
+        DataHandler dataHandler = mock(DataHandler.class);
+        this.lobStorage = mock(LobStorageInterface.class);
+
+        when(this.client.getSession()).thenReturn(session);
+        when(session.getDataHandler()).thenReturn(dataHandler);
+        when(dataHandler.getLobStorage()).thenReturn(this.lobStorage);
+        when(session.addTemporaryLob(any(ValueBlob.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(this.lobStorage.createBlob(any(InputStream.class), anyLong())).thenAnswer(invocation -> {
+            InputStream in = invocation.getArgument(0);
+            java.io.ByteArrayOutputStream buffer = new java.io.ByteArrayOutputStream();
+            byte[] chunk = new byte[256];
+            int n;
+            while ((n = in.read(chunk)) != -1) {
+                buffer.write(chunk, 0, n);
+            }
+            return ValueBlob.createSmall(buffer.toByteArray());
+        });
+    }
 
     @Test
     void decode() {
@@ -71,5 +110,47 @@ final class BlobCodecTest {
     void encodeNull() {
         assertThat(new BlobCodec(mock(Client.class)).encodeNull())
             .isEqualTo(ValueNull.INSTANCE);
+    }
+
+    @Test
+    void encodeReactiveDoesNotSubscribeUntilSubscribed() {
+        AtomicBoolean subscribed = new AtomicBoolean();
+        Blob blob = Blob.from(Flux.defer(() -> {
+            subscribed.set(true);
+            return Flux.just(ByteBuffer.wrap(TEST_BYTES));
+        }));
+
+        Mono<Value> encoded = new BlobCodec(this.client).encodeReactive(blob);
+
+        assertThat(subscribed).isFalse();
+
+        encoded.as(StepVerifier::create)
+            .assertNext(value -> assertThat(value.getBytesNoCopy()).isEqualTo(TEST_BYTES))
+            .verifyComplete();
+
+        assertThat(subscribed).isTrue();
+    }
+
+    @Test
+    void encodeReactiveOnParallelScheduler() {
+        Blob blob = Blob.from(Mono.just(ByteBuffer.wrap(TEST_BYTES)));
+
+        Mono.defer(() -> new BlobCodec(this.client).encodeReactive(blob))
+            .subscribeOn(Schedulers.parallel())
+            .as(StepVerifier::create)
+            .assertNext(value -> assertThat(value.getBytesNoCopy()).isEqualTo(TEST_BYTES))
+            .verifyComplete();
+    }
+
+    @Test
+    void encodeReactiveMultiChunk() {
+        byte[] part1 = "Hel".getBytes();
+        byte[] part2 = "lo".getBytes();
+        Blob blob = Blob.from(Flux.just(ByteBuffer.wrap(part1), ByteBuffer.wrap(part2)));
+
+        new BlobCodec(this.client).encodeReactive(blob)
+            .as(StepVerifier::create)
+            .assertNext(value -> assertThat(value.getBytesNoCopy()).isEqualTo(TEST_BYTES))
+            .verifyComplete();
     }
 }

--- a/src/test/java/io/r2dbc/h2/codecs/ClobCodecTest.java
+++ b/src/test/java/io/r2dbc/h2/codecs/ClobCodecTest.java
@@ -18,23 +18,61 @@ package io.r2dbc.h2.codecs;
 
 import io.r2dbc.h2.client.Client;
 import io.r2dbc.spi.Clob;
+import org.h2.engine.Session;
+import org.h2.store.DataHandler;
+import org.h2.store.LobStorageInterface;
 import org.h2.value.Value;
 import org.h2.value.ValueClob;
 import org.h2.value.ValueNull;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 
+import java.io.Reader;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 final class ClobCodecTest {
 
     String TEST = "hello你好こんにちはアロハ안녕하세요Здравствуйте";
     byte[] TEST_BYTES = TEST.getBytes(StandardCharsets.UTF_8);
+
+    private Client client;
+
+    private LobStorageInterface lobStorage;
+
+    @BeforeEach
+    void setUp() {
+        this.client = mock(Client.class);
+        Session session = mock(Session.class);
+        DataHandler dataHandler = mock(DataHandler.class);
+        this.lobStorage = mock(LobStorageInterface.class);
+
+        when(this.client.getSession()).thenReturn(session);
+        when(session.getDataHandler()).thenReturn(dataHandler);
+        when(dataHandler.getLobStorage()).thenReturn(this.lobStorage);
+        when(session.addTemporaryLob(any(ValueClob.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(this.lobStorage.createClob(any(Reader.class), anyLong())).thenAnswer(invocation -> {
+            Reader reader = invocation.getArgument(0);
+            StringBuilder sb = new StringBuilder();
+            char[] buf = new char[256];
+            int n;
+            while ((n = reader.read(buf)) != -1) {
+                sb.append(buf, 0, n);
+            }
+            return ValueClob.createSmall(sb.toString());
+        });
+    }
 
     @Test
     void decode() {
@@ -69,5 +107,45 @@ final class ClobCodecTest {
     void encodeNull() {
         assertThat(new ClobCodec(mock(Client.class)).encodeNull())
             .isEqualTo(ValueNull.INSTANCE);
+    }
+
+    @Test
+    void encodeReactiveDoesNotSubscribeUntilSubscribed() {
+        AtomicBoolean subscribed = new AtomicBoolean();
+        Clob clob = Clob.from(Flux.defer(() -> {
+            subscribed.set(true);
+            return Flux.just(TEST);
+        }));
+
+        Mono<Value> encoded = new ClobCodec(this.client).encodeReactive(clob);
+
+        assertThat(subscribed).isFalse();
+
+        encoded.as(StepVerifier::create)
+            .assertNext(value -> assertThat(value.getString()).isEqualTo(TEST))
+            .verifyComplete();
+
+        assertThat(subscribed).isTrue();
+    }
+
+    @Test
+    void encodeReactiveOnParallelScheduler() {
+        Clob clob = Clob.from(Mono.just(TEST));
+
+        Mono.defer(() -> new ClobCodec(this.client).encodeReactive(clob))
+            .subscribeOn(Schedulers.parallel())
+            .as(StepVerifier::create)
+            .assertNext(value -> assertThat(value.getString()).isEqualTo(TEST))
+            .verifyComplete();
+    }
+
+    @Test
+    void encodeReactiveMultiChunk() {
+        Clob clob = Clob.from(Flux.just("hello", "你好"));
+
+        new ClobCodec(this.client).encodeReactive(clob)
+            .as(StepVerifier::create)
+            .assertNext(value -> assertThat(value.getString()).isEqualTo("hello你好"))
+            .verifyComplete();
     }
 }

--- a/src/test/java/io/r2dbc/h2/codecs/MockCodecs.java
+++ b/src/test/java/io/r2dbc/h2/codecs/MockCodecs.java
@@ -18,6 +18,7 @@ package io.r2dbc.h2.codecs;
 
 import io.r2dbc.h2.util.Assert;
 import org.h2.value.Value;
+import reactor.core.publisher.Mono;
 import reactor.util.annotation.Nullable;
 
 import java.util.HashMap;
@@ -70,6 +71,11 @@ public final class MockCodecs implements Codecs {
         }
 
         return this.encodings.get(value);
+    }
+
+    @Override
+    public Mono<Value> encodeReactive(Object value) {
+        return Mono.fromCallable(() -> encode(value));
     }
 
     @Override


### PR DESCRIPTION
## Description

Fixes #129.

`BlobCodec` and `ClobCodec` consumed LOB publishers with `Flux.toIterable()` during `bind`/`encode`. On NonBlocking Reactor threads (e.g. `Schedulers.parallel()`, `reactor-http-nio-*`) that throws:

```
java.lang.IllegalStateException: Iterating over a toIterable() / toStream() is blocking,
which is not supported in thread reactor-http-nio-2
```

Per the issue guidance, stream consumption is deferred until statement execution.

### Changes

- **`BlobCodec` / `ClobCodec`**: reactive `encodeReactive` materialises streams with `Flux.reduceWith` (no `toIterable`/`block` on the bind path); discard after materialise
- **`Binding`**: optional deferred `Mono<Value>` parameters + `resolve()`
- **`H2Statement`**: Blob/Clob binds store deferred params; `execute` resolves via `concatMap` then prepares H2 commands
- **`Codecs.encodeReactive`**: public API for deferred encode (Parameter unwrap + LOB routing)
- **`BlobToByteBufferCodec`**: encode from `ByteBuffer` bytes directly (no pointless `Flux.just(...).toIterable()`)

## How to test

```bash
./mvnw test
# focused:
./mvnw -Dtest=BlobCodecTest,ClobCodecTest,BindingTest,H2LobIntegrationTest test
```

New coverage:

- unit: encode does not subscribe until Mono is subscribed; encode on `Schedulers.parallel()`
- IT: bind Blob/Clob on parallel scheduler insert; bind does not subscribe LOB stream until `execute()`

## Checklist

- [x] You have read the [Spring Code of Conduct](https://github.com/spring-projects/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] There is a ticket in the issue tracker for the bug or feature request this PR addresses
- [x] You use the code formatters provided [here](https://github.com/spring-io/spring-javaformat) and have them applied to your changes
- [x] You have added unit / integration tests for your bugfix / new feature